### PR TITLE
fix: use isActive field to define if the balance is complete

### DIFF
--- a/src/components/list/CardsList.tsx
+++ b/src/components/list/CardsList.tsx
@@ -162,7 +162,7 @@ export default function CardsList() {
                       <td className="px-3 py-4 text-sm text-gray-500 whitespace-nowrap">
                         {balance.counter}
                       </td>
-                      {balance.counter == balance.promotion?.checkoutLimit ? (
+                      {balance.isActive === false ? (
                         <td className="whitespace-nowrap px-3 py-4">
                           <span className='className="whitespace-nowrap inline-flex items-center rounded-md bg-green-50 px-2 py-1 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-600/20'>
                             {errorCode[200]['Promotion limit reached']}


### PR DESCRIPTION
### Changes proposed in this pull request
- use isActive field to define if the balance is complete
- 
-

[FID-204]


[FID-204]: https://msc-etna.atlassian.net/browse/FID-204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ